### PR TITLE
Add community and contributor files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug Report
+description: Report a bug in pyvenezuela
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior
+      description: What did you expect to happen, and what actually happened?
+    validations:
+      required: true
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: Python version
+      options:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
+    validations:
+      required: true
+  - type: input
+    id: package-version
+    attributes:
+      label: pyvenezuela version
+      placeholder: "0.0.4"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other relevant information (logs, screenshots, etc.).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://pyvenezuela.jose2kk.com
+    about: Check the docs for usage guides and API reference.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the feature you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case / motivation
+      description: Why is this feature needed? What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this could be implemented?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or features you've considered.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description
+
+<!-- What does this PR do? -->
+
+## Changes
+
+<!-- List the key changes -->
+
+-
+
+## Checklist
+
+- [ ] Tests pass (`make test`)
+- [ ] Linting passes (`make check`)
+- [ ] Documentation updated (if applicable)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,7 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it by emailing **jose2kk@gmail.com**. All reports will be reviewed and handled confidentially.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to pyvenezuela
+
+Thanks for your interest in contributing! This guide will help you get started.
+
+## Development setup
+
+1. Fork and clone the repository:
+
+   ```bash
+   git clone https://github.com/<your-username>/pyvenezuela.git
+   cd pyvenezuela
+   ```
+
+2. Install dependencies with [uv](https://docs.astral.sh/uv/):
+
+   ```bash
+   make setup
+   # or directly: uv sync --locked
+   ```
+
+## Running checks
+
+| Command         | Description                  |
+| --------------- | ---------------------------- |
+| `make test`     | Run the test suite           |
+| `make check`    | Run linting and type checks  |
+| `make format`   | Auto-format code with ruff   |
+| `make coverage` | Run tests with coverage      |
+
+## Submitting a pull request
+
+1. Create a feature branch from `main`:
+
+   ```bash
+   git checkout -b my-feature
+   ```
+
+2. Make your changes and add tests if applicable.
+
+3. Run formatting, linting, and tests:
+
+   ```bash
+   make format
+   make check
+   make test
+   ```
+
+4. Commit your changes with a clear, descriptive message.
+
+5. Push to your fork and open a pull request against `main`.
+
+6. Ensure CI passes on your PR.
+
+## Code style
+
+Code style is enforced by [ruff](https://docs.astral.sh/ruff/). Run `make format` before submitting and the formatter will take care of the rest. No need to worry about style nits in code review.
+
+## Questions?
+
+Feel free to open an issue if something is unclear. We are happy to help!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly by emailing **jose2kk@gmail.com**.
+
+**Do not** open a public issue for security vulnerabilities.
+
+You can expect an initial response within 48 hours.


### PR DESCRIPTION
## Summary
- Add CONTRIBUTING.md with dev setup, workflow, and code style guide
- Add CODE_OF_CONDUCT.md referencing Contributor Covenant v2.1
- Add SECURITY.md with vulnerability reporting instructions
- Add GitHub issue templates (bug report + feature request) as YAML forms
- Add pull request template with description and checklist

## Test plan
- [ ] Verify issue templates render correctly on GitHub (Settings > Issues > Templates)
- [ ] Verify PR template appears when opening a new PR
- [ ] Review CONTRIBUTING.md for accuracy