### PR TITLE
Add changelog, py.typed marker, and Python 3.14 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
       fail-fast: false
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `py.typed` marker for PEP 561 inline type support
+- Python 3.14 to test matrix and classifiers
+- This changelog
+
+## [0.0.4] - 2026-04-20
+
+### Changed
+
+- Migrated build system to uv
+- Added ty for type checking
+- Added mkdocs for documentation
+- Updated CI workflows
+
+## [0.0.3] - 2024-11-11
+
+### Added
+
+- In-memory cache implementation for API responses
+
+## [0.0.2] - 2024-11-11
+
+### Changed
+
+- Updated BCV client
+- Updated README
+
+## [0.0.1] - 2024-05-26
+
+### Added
+
+- Initial release
+- CNE client for querying cedula data
+- BCV client for querying exchange rates
+- PyPI package publishing
+
+[Unreleased]: https://github.com/jose2kk/pyvenezuela/compare/v0.0.4...HEAD
+[0.0.4]: https://github.com/jose2kk/pyvenezuela/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/jose2kk/pyvenezuela/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/jose2kk/pyvenezuela/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/jose2kk/pyvenezuela/releases/tag/v0.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md following Keep a Changelog format with history for all releases
- Add `py.typed` PEP 561 marker for downstream type checker support
- Add Python 3.14 to CI test matrix and pyproject.toml classifiers

## Test plan
- [ ] CI passes with Python 3.14 in the matrix
- [ ] `py.typed` is included in built wheel (`uv build && unzip -l dist/*.whl | grep py.typed`)