### PR TITLE
Fix Renovate silent mode preventing PR creation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "mode": "full",
   "extends": [
     "config:recommended",
     "schedule:earlyMondays",


### PR DESCRIPTION
## Summary
- Mend-hosted Renovate platform defaults to `mode=silent`, which prevents creation of branches, PRs, and the Dependency Dashboard
- Explicitly sets `mode=full` in `renovate.json` to override this default
- Renovate has 4 pending updates (GitHub Actions pin, setup-uv v8, Python 3.14, lock file maintenance) that will be created on the next run

## Test plan
- [ ] Merge this PR and wait for the next Renovate scheduled run (early Monday, per `schedule:earlyMondays`)
- [ ] Verify the Dependency Dashboard issue is created
- [ ] Verify Renovate opens PRs for pending dependency updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)